### PR TITLE
Правки в компоненті повідомлень

### DIFF
--- a/uk-UA_3.x/administrator/language/uk-UA/uk-UA.com_messages.ini
+++ b/uk-UA_3.x/administrator/language/uk-UA/uk-UA.com_messages.ini
@@ -1,5 +1,5 @@
 ; @version     3.9.18
-; @date        2020-04-28
+; @date        2020-05-08
 ; @author      Denys Nosov (Joomla! Ukraine)
 ; @copyright   Copyright (C) 2005-2020 Open Source Matters. All rights reserved.
 ; @copyright   2006-2020 (C) Joomla! Ukraine (https://joomla-ua.org). All rights reserved.
@@ -14,9 +14,9 @@ COM_MESSAGES_ADD="Нове приватне повідомлення"
 COM_MESSAGES_CONFIG_SAVED="Конфігурація збережена"
 COM_MESSAGES_CONFIGURATION="Повідомлення: параметри"
 COM_MESSAGES_ERR_INVALID_USER="Некоректний користувач"
-COM_MESSAGES_ERR_SEND_FAILED="Користувач заблокував свою поштову скриньку. Повідомлення не доставлено."
+COM_MESSAGES_ERR_SEND_FAILED="Користувач заблокував свою поштову скриньку. Повідомлення не може бути надіслано."
 COM_MESSAGES_ERROR_COULD_NOT_SEND_INVALID_RECIPIENT="Повідомлення не може бути відправлено через невірну адресу одержувача."
-COM_MESSAGES_ERROR_COULD_NOT_SEND_INVALID_REPLYTO="Повідомлення не може бути відправлено через некоректну зворотнб адресу."
+COM_MESSAGES_ERROR_COULD_NOT_SEND_INVALID_REPLYTO="Повідомлення не може бути відправлено через некоректну зворотну адресу."
 COM_MESSAGES_ERROR_INVALID_FROM_USER="Некоректний відправник"
 COM_MESSAGES_ERROR_INVALID_MESSAGE="Некоректний зміст повідомлення"
 COM_MESSAGES_ERROR_INVALID_SUBJECT="Некоректна тема"
@@ -63,14 +63,14 @@ COM_MESSAGES_N_ITEMS_TRASHED="%d повідомлення відправлені
 COM_MESSAGES_N_ITEMS_TRASHED_1="Повідомлення відправлене до кошика"
 COM_MESSAGES_N_ITEMS_UNPUBLISHED="%d повідомлення відмічені як непрочитані"
 COM_MESSAGES_N_ITEMS_UNPUBLISHED_1="Повідомлення відмічене як непрочитане"
-COM_MESSAGES_NEW_MESSAGE="Нове повідомлення від %2$s для %1$s"
+COM_MESSAGES_NEW_MESSAGE="Нове повідомлення від %1$s на %2$s"
 ; The following string is deprecated and will be removed in Joomla 4.0
 COM_MESSAGES_NEW_MESSAGE_ARRIVED="Отримано нове повідомлення від %s"
 COM_MESSAGES_NO_ITEM_SELECTED="Жодне повідомлення не вибране"
 COM_MESSAGES_OPTION_READ="Прочитане"
 COM_MESSAGES_OPTION_UNREAD="Непрочитане"
-COM_MESSAGES_PLEASE_LOGIN="Будь ласка, увійдіть до %s, щоб прочитати ваше повідомлення."
-COM_MESSAGES_RE="Відповідь на:"
+COM_MESSAGES_PLEASE_LOGIN="Будь ласка, перейдіть на наступну сторінку, щоб прочитати повідомлення:\n%s"
+COM_MESSAGES_RE="Re: "
 COM_MESSAGES_READ="Повідомлення"
 COM_MESSAGES_READ_PRIVATE_MESSAGE="Читати приватне повідомлення"
 COM_MESSAGES_SEARCH_IN_SUBJECT="Пошук в темі повідомлення або описі"
@@ -81,7 +81,7 @@ COM_MESSAGES_TOOLBAR_REPLY="Відповісти"
 COM_MESSAGES_TOOLBAR_SEND="Надіслати"
 COM_MESSAGES_VIEW_PRIVATE_MESSAGE="Менеджер приватних повідомлень: перегляд повідомлення"
 COM_MESSAGES_WRITE_PRIVATE_MESSAGE="Менеджер приватних повідомлень: написати приватне повідомлення"
-COM_MESSAGES_XML_DESCRIPTION="Компонент приватних повідомлень адміністративної частини сайту"
+COM_MESSAGES_XML_DESCRIPTION="Компонент для обміну приватними повідомленнями за допомогою панелі управління."
 JLIB_APPLICATION_SAVE_SUCCESS="Повідомлення успішно відправлено."
 JLIB_RULES_SETTING_NOTES="1. Якщо ви зміните налаштування, то воно буде застосоване до цього компонента. Зверніть увагу:<br><em>Успадковано</em> означає, що будуть використані права з глобальної конфігурації і з батьківської групи.<br><em>Відмовлено</em> означає, що немає значення, яка глобальна конфігурація або налаштування батьківської групи, бо при редагуванні група не зможе вибрати цю дію для даного компонента.<br><em>Дозволено</em> означає, що при редагуванні група зможе вибрати цю дію для даного компонента (та, якщо це конфліктує з глобальною конфігурацією або батьківською групою, то це не матиме впливу; конфлікт буде визначений як <em>Не дозволено (Заблоковано)</em> під Розрахункові Налаштування).<br>2. Якщо ви вибрали нове налаштування, то натисніть <em>Зберегти</em> для оновлення розрахункових налаштувань."
 

--- a/uk-UA_3.x/administrator/language/uk-UA/uk-UA.com_messages.sys.ini
+++ b/uk-UA_3.x/administrator/language/uk-UA/uk-UA.com_messages.sys.ini
@@ -1,5 +1,5 @@
 ; @version     3.9.18
-; @date        2020-04-28
+; @date        2020-05-08
 ; @author      Denys Nosov (Joomla! Ukraine)
 ; @copyright   Copyright (C) 2005-2020 Open Source Matters. All rights reserved.
 ; @copyright   2006-2020 (C) Joomla! Ukraine (https://joomla-ua.org). All rights reserved.
@@ -12,7 +12,4 @@
 COM_MESSAGES="Повідомлення"
 COM_MESSAGES_ADD="Нове приватне повідомлення"
 COM_MESSAGES_READ="Переглянути приватне повідомлення"
-
-[New Strings]
-
-COM_MESSAGES_XML_DESCRIPTION="Компонент для підтримки приватних повідомлень в адміністративній частині"
+COM_MESSAGES_XML_DESCRIPTION="Компонент для обміну приватними повідомленнями за допомогою панелі управління."

--- a/uk-UA_3.x/language/uk-UA/uk-UA.com_messages.ini
+++ b/uk-UA_3.x/language/uk-UA/uk-UA.com_messages.ini
@@ -1,5 +1,5 @@
 ; @version     3.9.18
-; @date        2020-04-26
+; @date        2020-05-08
 ; @author      Denys Nosov (Joomla! Ukraine)
 ; @copyright   2006-2020 (C) Joomla! Ukraine (https://joomla-ua.org). All rights reserved.
 ; @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -8,8 +8,8 @@
 ; @note        All ini files need to be saved as UTF-8
 
 
-COM_MESSAGES_ERR_SEND_FAILED="Користувач заблокував свою поштову скриньку. Повідомлення не надіслано."
+COM_MESSAGES_ERR_SEND_FAILED="Користувач заблокував свою поштову скриньку. Повідомлення не може бути надіслано."
 COM_MESSAGES_NEW_MESSAGE="Нове повідомлення від %1$s на %2$s"
 ; The following string is deprecated and will be removed in Joomla 4.0
 COM_MESSAGES_NEW_MESSAGE_ARRIVED="Нове приватне повідомлення від %s"
-COM_MESSAGES_PLEASE_LOGIN="Будь ласка, увійдіть до %s, щоб прочитати своє повідомлення."
+COM_MESSAGES_PLEASE_LOGIN="Будь ласка, перейдіть на наступну сторінку, щоб прочитати повідомлення:\n%s"


### PR DESCRIPTION
Добрий день.
Невеликі правки для компонента повідомлень.

Повідомлення в електронній пошті необхідно поміняти (я поміняв і для [російської мови](https://github.com/JPathRu/localisation/pull/40/files#diff-4fcdc287429635265e7798d2c9c9802b)), оскільки там не посилання на авторизацію, а безпосередньо посилання на перегляд повідомлення.

![Screenshot_1](https://user-images.githubusercontent.com/8440661/81350676-23b44900-90cb-11ea-9bd9-7e2c3c57b0da.png)

Тому краще так:

`COM_MESSAGES_PLEASE_LOGIN="Будь ласка, перейдіть на наступну сторінку, щоб прочитати повідомлення:\n%s"`

----------

Далі. Наступне повідомлення - це помилка при спробі відправки повідомлення, таке формулювання буде краще:

`COM_MESSAGES_ERR_SEND_FAILED="Користувач заблокував свою поштову скриньку. Повідомлення не може бути надіслано."`